### PR TITLE
Fix Illegal Lon Calc

### DIFF
--- a/FeBuddyLibrary/Helpers/LatLonHelpers.cs
+++ b/FeBuddyLibrary/Helpers/LatLonHelpers.cs
@@ -206,12 +206,13 @@ namespace FeBuddyLibrary.Helpers
 
         public static double CorrectIlleagleLon(double value)
         {
-            double tempvalue = Math.Abs(value);
-            if (tempvalue > 180)
+            if (value > 180)
             {
-                return (180 - (tempvalue % 180));
+                return ((value % 180) - 180);
+            } else if (value <= -180)
+            {
+                return (180 - (value % 180));
             }
-
             return value;
         }
 


### PR DESCRIPTION
Using ABS was restricting us from being able to work bi-directionally. This alters the % calc to properly evaluate E->W and W->E, as the % is dependent on the direction, and initial value.